### PR TITLE
Add priority breakdown

### DIFF
--- a/main.css
+++ b/main.css
@@ -71,3 +71,14 @@
 #wishlist-total .total-text {
   font-style: italic;
 }
+
+.wishlist-spacer {
+  width: 100px;
+  height: 1px;
+  margin: 8px auto 5px;
+  background-color: #dddddd;
+}
+
+.priority-item {
+  margin-top: 3px;
+}

--- a/main.js
+++ b/main.js
@@ -415,7 +415,16 @@ const calculateItemTotals = (items) => {
 // database meaningfully changes.
 const hashDatbaseForRendering = (database) => {
   const totals = calculateItemTotals(database.values());
-  return (totals.total_count * 31) + (totals.total_price * 7);
+
+  const priorityHash = Object.keys(totals.priorities).reduce((hash, priority) => {
+    let sum = 0;
+    for (let i = 0; i < priority.length; i++) {
+      sum += priority.charCodeAt(i);
+    }
+    return sum + hash;
+  }, 0);
+
+  return (priorityHash * 53) + (totals.total_count * 31) + (totals.total_price * 7);
 };
 
 // Re-render into `$root` only if the hash has changed since the last render.


### PR DESCRIPTION
# Background
I usually break up my lists by priority, and think it would help to see it broken down by priority.

Let me know if you want anything changed, or if this isn't something you want added. Thanks! 👍 

# Changes
When there are multiple priorities, they are shown under the total amount sorted by their amounts.

_I had to change the hash function to take them into account, and I used the priority labels for the hash._

# Screenshot

![image](https://user-images.githubusercontent.com/7807353/61192262-b9807280-a678-11e9-9c02-ca6654f23857.png)
